### PR TITLE
[DD-291] Add main index.js to js-evo-services-ctl

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib');


### PR DESCRIPTION
The main `index.js` is required so it can be used as a proper NPM package.