### PR TITLE
docs: conventional commits

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# Always validate all commits, and ignore the PR title
+commitsOnly: true
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+## Commit message format
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for commit messages and expect from you the same.
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+[optional body]
+[optional footer(s)]
+```


### PR DESCRIPTION
[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
A specification for adding human and machine readable meaning to commit messages