### PR TITLE
fix: Use new mongo server discovery engine

### DIFF
--- a/lib/services/mongoDb/MongoDb.js
+++ b/lib/services/mongoDb/MongoDb.js
@@ -172,6 +172,7 @@ class MongoDb extends DockerService {
 
         this.mongoClient = await this.MongoClient.connect(
           address, {
+            useUnifiedTopology: true,
             useNewUrlParser: true,
           },
         );


### PR DESCRIPTION
This passes option `{ useUnifiedTopology: true }` to the MongoClient constructor, and fixes the `DeprecationWarning: current Server Discovery and Monitoring engine` seen in tests and Travis.