### PR TITLE
fix: socket hang up when connecting from host

### DIFF
--- a/lib/services/dashCore/DashCoreOptions.js
+++ b/lib/services/dashCore/DashCoreOptions.js
@@ -38,6 +38,7 @@ class DashCoreOptions extends DockerServiceOptions {
         `-rpcuser=${defaultServiceOptions.rpcuser}`,
         `-rpcpassword=${defaultServiceOptions.rpcpassword}`,
         '-rpcallowip=0.0.0.0/0',
+        '-rpcbind=0.0.0.0',
         '-regtest=1',
         '-keypool=1',
         '-addressindex=1',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The update to Core 18.0.0 seems to have changed the behaviour of which IPs are allowed. Insight-ui (which use this repo to set up tests) was not able to run tests because the host could not communicate with the container, resulting in `error: socket hang up` (JS) or `error code 1 - "EOF reached"` (dash-cli) while running mocha.

## What was done?
<!--- Describe your changes in detail -->
Set `rpcbind=0.0.0.0`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
